### PR TITLE
Hardcode the script path back, support `~/bin` and `~/.local/bin`

### DIFF
--- a/deploy_bash_completion
+++ b/deploy_bash_completion
@@ -1,4 +1,12 @@
 #!/bin/bash
-DEPLOY=$(which deploy)
-SITES=$("$DEPLOY" | tail --lines=+2)
-complete -W "$SITES" deploy
+DEPLOY=""
+if [ -x "$HOME/bin/deploy" ]; then
+	DEPLOY=$HOME/bin/deploy
+fi
+if [ -x "$HOME/.local/bin/deploy" ]; then
+	DEPLOY=$HOME/.local/bin/deploy
+fi
+if [ "$DEPLOY" != "" ]; then
+	SITES=$($DEPLOY | tail --lines=+2)
+	complete -W "$SITES" deploy
+fi


### PR DESCRIPTION
Bash completion is loaded in `~/.bashrc` which is loaded in `~/.profile`, but `~/bin` (or `~/.local/bin`) is added in `~/.profile` only *after* `.bashrc` is loaded so the path is not available in bash completion.

Reverts/updates #18