### PR TITLE
Readme symlinks to include filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 ## Installation
 1. Symlink `deploy` to `~/.local/bin` or similar
 2. Symlink `git_ssh_wrapper` to `~/.local/bin` or similar
-3. Symlink `deploy_bash_completion` to `~/.local/share/bash-completion/completions`
+3. Create a symlink in `~/.local/share/bash-completion/completions` named `deploy` that points to `deploy_bash_completion` – the symlink's filename has to be `deploy`, otherwise the completion won't work.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # stupid-git-deploy
 
 ## Installation
-1. Symlink `deploy` to `~/.local/bin` or similar
-2. Symlink `git_ssh_wrapper` to `~/.local/bin` or similar
-3. Create a symlink in `~/.local/share/bash-completion/completions` named `deploy` that points to `deploy_bash_completion` – the symlink's filename has to be `deploy`, otherwise the completion won't work.
+Create the following symlinks:
+1. `~/.local/bin/deploy` (or `~/bin/deploy`) that points to `deploy`
+2. `~/.local/bin/git_ssh_wrapper` (or `~/bin/git_ssh_wrapper`) that points to `git_ssh_wrapper`
+3. `~/.local/share/bash-completion/completions/deploy` that points to `deploy_bash_completion` – the symlink's filename has to be `deploy`, otherwise the completion won't work


### PR DESCRIPTION
The completion doesn't work in `.local` if the completion file doesn't have the same name as the invoked command, unlike in `/etc/bash_completion.d`.

This is also explained in https://github.com/scop/bash-completion#faq:
> From this directory, completions are automatically loaded on demand based on invoked commands' names, so be sure to name your completion file accordingly, and to include (for example) symbolic links in case the file provides completions for more than one command. The completion filename for command `foo` in this directory should be either `foo`, or `foo.bash`.

Ok, @copilot was [right](https://github.com/spaze/stupid-git-deploy/pull/21/files/402de4645648b68f98efc234eda79b580b78626f#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).

Follow-up to #18 and #21