### PR TITLE
Verify deploys against a signed git tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # stupid-git-deploy
 
 A stupidly simple bash script to deploy a site from Git(Hub): fetch, check out the
-new code, run `composer install`, purge the cache, strip dev dependencies, and
+new code, run `composer install --no-dev`, purge the cache, strip dev dependencies, and
 hit the site as a healthcheck.
 
 Before deploying anything, it verifies that the code was **authorized by you**:
@@ -17,7 +17,9 @@ below for exactly what that does and does not buy you.
    deploy over ssh.
 2. On the server, `deploy <site>` fetches the tag, checks its signature against a
    local allow-list of your public key(s), and refuses to continue unless it's a
-   valid, fast-forward-only move. Only then does it touch the working tree.
+   valid, fast-forward-only move. Only then does it check out the new code. Any
+   `docs/deploy/init` and `conf/deploy/init` hooks in the current checkout run
+   before that verification.
 
 The tag is *authorization* ("I, holder of the key, approve deploying this"). The
 server never trusts GitHub, a password, a token, or its own push credentials for

--- a/README.md
+++ b/README.md
@@ -1,7 +1,146 @@
 # stupid-git-deploy
 
+A stupidly simple bash script to deploy a site from Git(Hub): fetch, check out the
+new code, run `composer install`, purge the cache, strip dev dependencies, and
+hit the site as a healthcheck.
+
+Before deploying anything, it verifies that the code was **authorized by you**:
+it will only deploy a commit that a Git tag named `deploy`, signed with *your*
+SSH key, points at. See [What this protects](#what-this-protects-and-what-it-does-not)
+below for exactly what that does and does not buy you.
+
+## How it works
+
+1. On your workstation you review what you're about to ship, then run
+   `sign-deploy <site>`. That signs a moving `deploy` tag over your current commit
+   (with your SSH key, e.g. from 1Password), force-pushes it, and triggers the
+   deploy over ssh.
+2. On the server, `deploy <site>` fetches the tag, checks its signature against a
+   local allow-list of your public key(s), and refuses to continue unless it's a
+   valid, fast-forward-only move. Only then does it touch the working tree.
+
+The tag is *authorization* ("I, holder of the key, approve deploying this"). The
+server never trusts GitHub, a password, a token, or its own push credentials for
+that decision — only your off-machine signing key.
+
 ## Installation
-Create the following symlinks:
-1. `~/.local/bin/deploy` (or `~/bin/deploy`) that points to `deploy`
-2. `~/.local/bin/git_ssh_wrapper` (or `~/bin/git_ssh_wrapper`) that points to `git_ssh_wrapper`
-3. `~/.local/share/bash-completion/completions/deploy` that points to `deploy_bash_completion` – the symlink's filename has to be `deploy`, otherwise the completion won't work
+
+### On the server (where the site is deployed)
+
+Symlink the scripts and completion:
+
+1. `~/.local/bin/deploy` (or `~/bin/deploy`) → `deploy`
+2. `~/.local/bin/git_ssh_wrapper` (or `~/bin/git_ssh_wrapper`) → `git_ssh_wrapper`
+3. `~/.local/share/bash-completion/completions/deploy` → `deploy_bash_completion`
+   – the symlink's filename has to be `deploy`, otherwise the completion won't work
+
+Then create the **allow-list of signing keys** — this is the one required piece
+of trust configuration. It holds the *public* half of the SSH key you sign tags
+with; it is what lets the server tell your tag from anybody else's:
+
+```sh
+mkdir -p ~/.config/deploy
+# one line per authorized key; the first field is a label of your choice (Git ignores it)
+echo 'you@example.com ssh-ed25519 AAAA...your-signing-pubkey...' > ~/.config/deploy/allowed_signers
+```
+
+Overridable via env:
+
+- `STUPID_GIT_DEPLOY_ALLOWED_SIGNERS` (default `~/.config/deploy/allowed_signers`)
+- `STUPID_GIT_DEPLOY_LOCK` (default `~/.local/state/deploy/locks/<site>.lock`)
+- `STUPID_GIT_DEPLOY_LOG` (default `~/.local/state/deploy/deploy.log`)
+- `STUPID_GIT_DEPLOY_ROOT` (default `/srv/www`)
+- `STUPID_GIT_DEPLOY_TAG` (default `deploy`)
+
+Requires **Git ≥ 2.34** (for SSH signature verification) and **`flock`** (from
+util-linux, for the per-site lock); the script refuses to run without them.
+
+Deploys of the same site are serialized with a lock: if one is already running,
+a second run of that site exits immediately rather than racing on it. Different
+sites deploy independently.
+
+The meaningful outcomes are appended to the deploy log with the site and commit
+SHAs: successful deploys (`ok`) and — importantly — the two verification
+refusals, an unauthorized signature (`badsig`) and a rejected
+rollback/non-fast-forward (`nonff`). It's a plain local file, so treat it as an
+audit aid, not a tamper-proof record. Operational aborts (Git too old, fetch
+failed, and so on) print a message and exit without a log line.
+
+### On your workstation (where you deploy from)
+
+1. Symlink `sign-deploy` into your `PATH`, e.g. `~/.local/bin/sign-deploy` → `sign-deploy`.
+2. Make sure Git is set up to SSH-sign (once, globally):
+   `git config --global gpg.format ssh` and
+   `git config --global user.signingkey key::ssh-ed25519 AAAA...` (or your 1Password
+   config). The *public* key must match a line in the server's `allowed_signers`.
+3. Tell `sign-deploy` where the server is:
+   ```sh
+   export STUPID_GIT_DEPLOY_HOST=your.server.example
+   ```
+   By default it runs `~/.local/bin/deploy` on the server (matching the install
+   above — the `~` is expanded on the server, so it works even if your home
+   directory differs there). Set `STUPID_GIT_DEPLOY_REMOTE` only if you
+   installed `deploy` somewhere else.
+
+## Deploying
+
+```sh
+git pull # get the merged code
+git log --oneline <last>.. # REVIEW what you're about to ship (see below)
+sign-deploy <site> # sign, push the tag, trigger the server
+```
+
+Because your signature *is* the authorization, the review step is not optional —
+see below.
+
+## What this protects, and what it does not
+
+Plain English, so there are no surprises.
+
+### What it protects against
+
+- **Deploying anything you didn't sign off on.** Nothing reaches the site unless
+  it carries a `deploy` tag signed by your SSH key. Someone with a stolen GitHub
+  password, a stolen API token, push access to the repo, or even control of
+  GitHub itself **cannot** forge that signature — your signing key never leaves
+  your machine / 1Password.
+- **Tampering with the exact code deployed.** The signature is bound to the exact
+  commit, which is bound to every file in it. Change one byte and the signature no
+  longer matches, so the server refuses it.
+- **Rollback / replay attacks.** You can't be tricked into re-deploying an older
+  (perhaps vulnerable) version by replaying an old signed tag — the server only
+  moves *forward* (fast-forward-only) and refuses to go back.
+- **A compromised GitHub.** The server doesn't trust GitHub's own commit
+  signatures at all, so a compromise on GitHub's side still can't get code onto
+  your server without your signature.
+
+### What it does NOT protect against
+
+- **A malicious commit you didn't notice before signing.** The server does *not*
+  check who wrote each individual commit between the last deploy and now — it
+  trusts that when you signed the tag, you looked. If you sign without reviewing,
+  a bad commit hidden inside a merged pull request (say, from a compromised
+  contributor or dependency PR) **will be deployed**. Reviewing the changes
+  before `sign-deploy` is the control that catches this; it is the price of the
+  simple design. Deploying many times a day, the real risk here is rubber-stamping.
+- **Theft of your signing key.** Whoever holds your SSH signing key (1Password)
+  can authorize a deploy of anything. This scheme puts all trust in that one key.
+- **What's inside Git submodules.** The signature pins *which* submodule commit is
+  used, but the server doesn't verify the contents behind that pin — a submodule
+  points at a separate repo with its own trust.
+- **Someone hiding newer commits from you (a "freeze").** If the origin quietly
+  withholds updates, you'll simply keep deploying your latest known-good version.
+  That's safe (nothing malicious ships), just not fresh.
+- **Rollbacks.** There's no rollback command — the forward-only rule is
+  deliberate. To undo, make a new commit that reverts the change and deploy that.
+- **The code already on the server at setup.** The forward-only rule is anchored
+  on whatever commit the server currently has checked out, and that starting
+  point is trusted as-is (never signature-checked). Set the server up at a
+  known-good commit; the "nothing ships without your signature" guarantee applies
+  to everything deployed *after* that first point.
+
+### Rotating your key
+
+Add the new public key as another line in the server's `allowed_signers`. Keep
+the old line until every server has been deployed at least once with the new key,
+then remove it.

--- a/deploy
+++ b/deploy
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-ROOT=/srv/www
 APP_DIR=app
 VENDOR_DIR=$APP_DIR/vendor
-VENDOR_PATHDIR=$ROOT/$1/$VENDOR_DIR
 COMPOSER_LOCK=$APP_DIR/composer.lock
 COMPOSER_JSON=$APP_DIR/composer.json
 INSTALLED_PHP=$VENDOR_DIR/composer/installed.php
@@ -11,17 +9,12 @@ AUTOLOAD_FILES=$VENDOR_DIR/composer/autoload_files.php
 VENDOR_IGNORE=$VENDOR_DIR/.gitignore
 CACHE_DIR=$APP_DIR/temp/cache
 GIT_SSH_WRAPPER=git_ssh_wrapper
-
-if [ $# -eq 0 ]; then
-	echo "$0 <site>, where site is:"
-	ls -1 $ROOT
-	exit 1
-fi
-
-if [ ! -d "$ROOT/$1" ]; then
-	echo "Site $1 doesn't exist"
-	exit 2
-fi
+STUPID_GIT_DEPLOY_ROOT=${STUPID_GIT_DEPLOY_ROOT:-/srv/www}
+STUPID_GIT_DEPLOY_TAG=${STUPID_GIT_DEPLOY_TAG:-deploy}
+STUPID_GIT_DEPLOY_ALLOWED_SIGNERS=${STUPID_GIT_DEPLOY_ALLOWED_SIGNERS:-$HOME/.config/deploy/allowed_signers}
+STUPID_GIT_DEPLOY_LOG=${STUPID_GIT_DEPLOY_LOG:-$HOME/.local/state/deploy/deploy.log}
+STUPID_GIT_DEPLOY_LOCK=${STUPID_GIT_DEPLOY_LOCK:-$HOME/.local/state/deploy/locks/$1.lock}
+VENDOR_PATHDIR=$STUPID_GIT_DEPLOY_ROOT/$1/$VENDOR_DIR
 
 BOLD=$(tput bold)
 RED=$(tput setaf 1)
@@ -30,9 +23,58 @@ MAGENTA=$(tput setaf 5)
 GRAY=$(tput setaf 243)  # will only work with TERM=xterm-256color
 NORMAL=$(tput sgr0)
 
+# No `set -e` here, so failures must be handled explicitly (`|| fail`, or `exit`).
+# fail [exit-code] message (exit-code defaults to 1)
+fail() {
+	local code=1
+	[[ ${1:-} =~ ^[0-9]+$ ]] && [ $# -ge 2 ] && { code=$1; shift; }
+	echo "${BOLD}${RED}DEPLOY ABORTED: $*${NORMAL}" >&2
+	exit "$code"
+}
+
+# Log only SHAs/fixed words, never author/subject, so a crafted commit can't
+# forge log lines.  Args: site result tagobj commit prev
+deploy_log() {
+	mkdir -p -- "$(dirname -- "$STUPID_GIT_DEPLOY_LOG")" 2>/dev/null
+	printf 'ts=%s site=%s result=%s tag=%s commit=%s prev=%s\n' \
+		"$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$2" "$3" "$4" "$5" >> "$STUPID_GIT_DEPLOY_LOG" 2>/dev/null \
+		|| echo "WARNING: could not write audit log $STUPID_GIT_DEPLOY_LOG" >&2
+}
+
+if [ $# -eq 0 ]; then
+	echo "$0 <site> [<commit>]"
+	echo "  <commit>: optional, passed by sign-deploy; deploy only if the signed tag still points at it"
+	echo "site is one of:"
+	ls -1 -- "$STUPID_GIT_DEPLOY_ROOT"
+	exit 1
+fi
+
+if ! [[ $1 =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+	fail 2 "invalid site name '$1' (letters, digits, dot, dash, underscore only)"
+fi
+
+if ! [[ $STUPID_GIT_DEPLOY_ROOT =~ ^[A-Za-z0-9/._][A-Za-z0-9/._-]*$ ]]; then
+	fail 2 "unsafe STUPID_GIT_DEPLOY_ROOT '$STUPID_GIT_DEPLOY_ROOT' (letters, digits, / . _ -; must not start with -)"
+fi
+
+if ! [[ $STUPID_GIT_DEPLOY_TAG =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
+	fail 2 "unsafe STUPID_GIT_DEPLOY_TAG '$STUPID_GIT_DEPLOY_TAG'"
+fi
+
+if [ ! -d "$STUPID_GIT_DEPLOY_ROOT/$1" ]; then
+	echo "Site $1 doesn't exist"
+	exit 2
+fi
+
+# Don't let two deploys of the same site run at the same time.
+command -v flock >/dev/null 2>&1 || fail "flock not found (install util-linux)"
+mkdir -p -- "$(dirname -- "$STUPID_GIT_DEPLOY_LOCK")" 2>/dev/null
+exec 9>"$STUPID_GIT_DEPLOY_LOCK" || fail "cannot open lock file $STUPID_GIT_DEPLOY_LOCK"
+flock -n 9 || fail "could not acquire deploy lock $STUPID_GIT_DEPLOY_LOCK for $1 (another deploy may be running)"
+
 echo "${BOLD}Deploying ${GREEN}$1${NORMAL}"
 
-cd "$ROOT/$1" || { echo "$ROOT/$1 doesn't exist, aborting"; exit 1; }
+cd "$STUPID_GIT_DEPLOY_ROOT/$1" || { echo "$STUPID_GIT_DEPLOY_ROOT/$1 doesn't exist, aborting"; exit 1; }
 
 for I in docs conf; do
 	if [ -x "./$I/deploy/init" ]; then
@@ -48,22 +90,60 @@ for I in docs conf; do
 done
 
 GIT_SSH_KEY=$HOME/.ssh/web-$1.key
-GIT_SSH=$(which $GIT_SSH_WRAPPER)
+GIT_SSH=$(command -v "$GIT_SSH_WRAPPER")
 if [ "$GIT_SSH" == "" ]; then
 	echo "$GIT_SSH_WRAPPER not found in path, exiting"
 	exit
 fi
 export GIT_SSH_KEY GIT_SSH
-git fetch
+
+# Refuse to deploy anything the signed "$STUPID_GIT_DEPLOY_TAG" tag doesn't authorize.
+
+command -v git >/dev/null 2>&1 || fail "Git not found"
+command -v ssh-keygen >/dev/null 2>&1 || fail "ssh-keygen from OpenSSH not found (needed to verify the tag signature)"
+# Git >= 2.34 verifies SSH signatures
+GITVER=$(git --version | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+printf '2.34\n%s\n' "$GITVER" | sort -V -C || fail "Git >= 2.34 required for SSH tag verification (have ${GITVER:-unknown})"
+
+# --force: the deploy tag is re-pointed on every deploy
+git fetch --force origin tag "$STUPID_GIT_DEPLOY_TAG" || fail "could not fetch tag '$STUPID_GIT_DEPLOY_TAG' from origin"
+
+# Pin the tag object once so verify and checkout use the same object.
+TAGOBJ=$(git rev-parse --verify "refs/tags/$STUPID_GIT_DEPLOY_TAG" 2>/dev/null) || fail "tag '$STUPID_GIT_DEPLOY_TAG' missing after fetch"
+
+[ -r "$STUPID_GIT_DEPLOY_ALLOWED_SIGNERS" ] || fail "allowed_signers not found or unreadable: $STUPID_GIT_DEPLOY_ALLOWED_SIGNERS"
+# Empty GNUPGHOME: only $STUPID_GIT_DEPLOY_ALLOWED_SIGNERS decides trust, not any ambient GPG key.
+EMPTY_GNUPGHOME=$(mktemp -d) || fail "could not create a temporary GNUPGHOME"
+trap 'rm -rf "$EMPTY_GNUPGHOME"' EXIT
+if ! GNUPGHOME="$EMPTY_GNUPGHOME" git -c gpg.ssh.allowedSignersFile="$STUPID_GIT_DEPLOY_ALLOWED_SIGNERS" verify-tag "$TAGOBJ"; then
+	deploy_log "$1" badsig "$TAGOBJ" - "$(git rev-parse HEAD 2>/dev/null)"
+	fail "tag '$STUPID_GIT_DEPLOY_TAG' ($TAGOBJ) is NOT signed by an authorized key; refusing to deploy"
+fi
+
+candidate=$(git rev-parse --verify "$TAGOBJ^{commit}" 2>/dev/null) || fail "tag '$STUPID_GIT_DEPLOY_TAG' does not point at a commit"
+
+if [ -n "${2:-}" ] && [ "$candidate" != "$2" ]; then
+	fail "deploy tag points at $candidate, not the commit you signed (raced?); re-run"
+fi
+
+anchor=$(git rev-parse --verify HEAD 2>/dev/null) || fail "cannot resolve current HEAD"
+
+# Fast-forward only: refuse rollback / replay / diverged history.
+if ! git merge-base --is-ancestor "$anchor" "$candidate"; then
+	deploy_log "$1" nonff "$TAGOBJ" "$candidate" "$anchor"
+	fail "verified commit $candidate is not a fast-forward from live $anchor (rollback/replay/diverged); refusing"
+fi
+
 echo -n "${BOLD}${MAGENTA}"
-git reset origin --hard
+git reset --hard "$candidate" || { echo -n "$NORMAL"; fail "git reset --hard $candidate failed"; }
 echo -n "$NORMAL"
-git submodule update --init --recursive
+
+git submodule update --init --recursive || fail "submodule update failed"
 
 if [ -d "$VENDOR_DIR" ]; then
 	echo "Removing untracked files in $VENDOR_DIR:"
 	echo -n "$GRAY"
-	git clean -x --force $VENDOR_DIR
+	git clean -x --force $VENDOR_DIR || { echo -n "$NORMAL"; fail "git clean of $VENDOR_DIR failed"; }
 	echo -n "$NORMAL"
 	echo "Untracked files in $VENDOR_DIR removed"
 fi
@@ -71,19 +151,19 @@ fi
 if [ -f "$COMPOSER_LOCK" ] && [ -f "$VENDOR_IGNORE" ]; then
 	CURRENT_DIR=$(pwd)
 	cd $APP_DIR || { echo "$APP_DIR doesn't exist, aborting"; exit 1; }
-	composer install --no-dev
+	composer install --no-dev || fail "composer install failed"
 	echo "${BOLD}Composer dependencies installed${NORMAL}"
 	cd "$CURRENT_DIR" || { echo "$CURRENT_DIR doesn't exist anymore?"; exit 1; }
 fi
 
 if [ -d "$CACHE_DIR" ]; then
-	sudo rm -r $CACHE_DIR
+	sudo rm -r $CACHE_DIR || fail "could not purge cache $CACHE_DIR"
 	echo "${BOLD}Cache purged${NORMAL}"
 fi
 
 if [ -f "$COMPOSER_JSON" ]; then
 	# shellcheck disable=SC2016 # The variables in single quotes are PHP code
-	DEV_DEPS=$(php -r '$deps = []; foreach ((require "'$INSTALLED_PHP'")["versions"] as $k => $v) if ($v["dev_requirement"]) $deps[] = $k; echo implode(PHP_EOL, $deps);')
+	DEV_DEPS=$(php -r '$deps = []; foreach ((require "'$INSTALLED_PHP'")["versions"] as $k => $v) if ($v["dev_requirement"]) $deps[] = $k; echo implode(PHP_EOL, $deps);') || fail "could not read dev dependencies from $INSTALLED_PHP"
 	if [ -z "$DEV_DEPS" ]; then
 		echo "${GRAY}No dev dependencies found in $INSTALLED_PHP${NORMAL}"
 	else
@@ -93,7 +173,7 @@ if [ -f "$COMPOSER_JSON" ]; then
 			if [ ! -d "./$VENDOR_DIR/$DEP" ]; then
 				continue
 			fi
-			rm -rf "./$VENDOR_DIR/$DEP"/*
+			rm -rf "./$VENDOR_DIR/$DEP"/* || fail "could not remove dev dependency $DEP"
 			echo "Removed by $0" > "./$VENDOR_DIR/$DEP/REMOVED-BY-DEPLOY"
 			echo "├ $DEP removed"
 		done
@@ -101,16 +181,17 @@ if [ -f "$COMPOSER_JSON" ]; then
 		if [ -f "$AUTOLOAD_FILES" ]; then
 			echo "${BOLD}Re-creating files required by $AUTOLOAD_FILES${NORMAL}"
 			# shellcheck disable=SC2016 # The variables in single quotes are PHP code
-			REQUIRED_FILES=$(php -r 'foreach (require "'$AUTOLOAD_FILES'" as $file) { echo preg_replace("~^" . preg_quote("'"$VENDOR_PATHDIR"'", "~") . "/~", "", $file) . PHP_EOL; }')
-			for REQUIRED_FILE in $REQUIRED_FILES; do
+			REQUIRED_FILES=$(php -r 'foreach (require "'$AUTOLOAD_FILES'" as $file) { echo preg_replace("~^" . preg_quote("'"$VENDOR_PATHDIR"'", "~") . "/~", "", $file) . PHP_EOL; }') || fail "could not read required files from $AUTOLOAD_FILES"
+			while IFS= read -r REQUIRED_FILE; do
+				[ -n "$REQUIRED_FILE" ] || continue
 				REQUIRED_PATHFILE=$VENDOR_PATHDIR/$REQUIRED_FILE
 				if [ -f "$REQUIRED_PATHFILE" ]; then
 					echo "├ ${GRAY}$REQUIRED_FILE exists${NORMAL}"
 				else
-					echo "<?php // $REQUIRED_FILE re-created empty by $0, required by $AUTOLOAD_FILES" > "$REQUIRED_PATHFILE"
+					echo "<?php // $REQUIRED_FILE re-created empty by $0, required by $AUTOLOAD_FILES" > "$REQUIRED_PATHFILE" || fail "could not re-create $REQUIRED_PATHFILE"
 					echo "├ $REQUIRED_FILE re-created"
 				fi
-			done
+			done <<< "$REQUIRED_FILES"
 			echo "└ ${BOLD}Done${NORMAL}"
 		else
 			echo "${GRAY}$AUTOLOAD_FILES not found, won't re-create any files${NORMAL}"
@@ -130,4 +211,5 @@ curl \
 --write-out "%{url_effective} -> HTTP %{http_code} (in %{time_total}s)\n" \
 "$1" | sed "s/\(HTTP 2[0-9]\+\)/${BOLD}${GREEN}\\1${NORMAL}/" | sed "s/\(HTTP 5[0-9]\+\)/${BOLD}${RED}\\1 FAILURE${NORMAL}/"
 
+deploy_log "$1" ok "$TAGOBJ" "$candidate" "$anchor"
 echo "${BOLD}${GREEN}$1 successfully deployed${NORMAL}"

--- a/deploy
+++ b/deploy
@@ -32,8 +32,8 @@ fail() {
 	exit "$code"
 }
 
-# Log only SHAs/fixed words, never author/subject, so a crafted commit can't
-# forge log lines.  Args: site result tagobj commit prev
+# Log only fixed words, SHAs, and the validated site, never author/subject,
+# so a crafted commit can't forge log lines. Args: site result tagobj commit prev
 deploy_log() {
 	mkdir -p -- "$(dirname -- "$STUPID_GIT_DEPLOY_LOG")" 2>/dev/null
 	printf 'ts=%s site=%s result=%s tag=%s commit=%s prev=%s\n' \

--- a/deploy
+++ b/deploy
@@ -62,8 +62,7 @@ if ! [[ $STUPID_GIT_DEPLOY_TAG =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
 fi
 
 if [ ! -d "$STUPID_GIT_DEPLOY_ROOT/$1" ]; then
-	echo "Site $1 doesn't exist"
-	exit 2
+	fail 2 "site $1 doesn't exist"
 fi
 
 # Don't let two deploys of the same site run at the same time.
@@ -74,15 +73,14 @@ flock -n 9 || fail "could not acquire deploy lock $STUPID_GIT_DEPLOY_LOCK for $1
 
 echo "${BOLD}Deploying ${GREEN}$1${NORMAL}"
 
-cd "$STUPID_GIT_DEPLOY_ROOT/$1" || { echo "$STUPID_GIT_DEPLOY_ROOT/$1 doesn't exist, aborting"; exit 1; }
+cd "$STUPID_GIT_DEPLOY_ROOT/$1" || fail "$STUPID_GIT_DEPLOY_ROOT/$1 doesn't exist"
 
 for I in docs conf; do
 	if [ -x "./$I/deploy/init" ]; then
 		./$I/deploy/init
 		RET_VAL=$?
 		if [ ! $RET_VAL -eq 0 ]; then
-			echo "$I/deploy/init returned error $RET_VAL, exiting"
-			exit
+			fail "$RET_VAL" "$I/deploy/init returned error $RET_VAL"
 		fi
 	elif [ -f "./$I/deploy/init" ]; then
 		echo "$I/deploy/init exists but it's not executable, skipping"
@@ -92,8 +90,7 @@ done
 GIT_SSH_KEY=$HOME/.ssh/web-$1.key
 GIT_SSH=$(command -v "$GIT_SSH_WRAPPER")
 if [ "$GIT_SSH" == "" ]; then
-	echo "$GIT_SSH_WRAPPER not found in path, exiting"
-	exit
+	fail "$GIT_SSH_WRAPPER not found in path"
 fi
 export GIT_SSH_KEY GIT_SSH
 
@@ -150,10 +147,10 @@ fi
 
 if [ -f "$COMPOSER_LOCK" ] && [ -f "$VENDOR_IGNORE" ]; then
 	CURRENT_DIR=$(pwd)
-	cd $APP_DIR || { echo "$APP_DIR doesn't exist, aborting"; exit 1; }
+	cd $APP_DIR || fail "$APP_DIR doesn't exist"
 	composer install --no-dev || fail "composer install failed"
 	echo "${BOLD}Composer dependencies installed${NORMAL}"
-	cd "$CURRENT_DIR" || { echo "$CURRENT_DIR doesn't exist anymore?"; exit 1; }
+	cd "$CURRENT_DIR" || fail "$CURRENT_DIR doesn't exist anymore?"
 fi
 
 if [ -d "$CACHE_DIR" ]; then

--- a/git_ssh_wrapper
+++ b/git_ssh_wrapper
@@ -1,2 +1,5 @@
 #!/bin/sh
-$(which ssh) -i "$GIT_SSH_KEY" "$@"
+
+[ -r "$GIT_SSH_KEY" ] || { echo "git_ssh_wrapper: deploy key not readable: $GIT_SSH_KEY" >&2; exit 1; }
+ssh_bin=$(command -v ssh) || { echo "git_ssh_wrapper: ssh not found in PATH" >&2; exit 2; }
+exec "$ssh_bin" -i "$GIT_SSH_KEY" "$@"

--- a/sign-deploy
+++ b/sign-deploy
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# sign-deploy <site>: sign a "deploy" tag over local HEAD and trigger the
+# server, which verifies the signature before deploying. Pull and review your
+# changes first: your signature IS the authorization. Warns, never blocks, on a
+# dirty or off-branch HEAD.
+set -euo pipefail
+
+SITE=${1:?usage: sign-deploy <site>}
+if ! [[ $SITE =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+	echo "Invalid site name '$SITE' (letters, digits, dot, dash, underscore only)" >&2
+	exit 2
+fi
+STUPID_GIT_DEPLOY_HOST=${STUPID_GIT_DEPLOY_HOST:?set STUPID_GIT_DEPLOY_HOST (e.g. export STUPID_GIT_DEPLOY_HOST=deploy.example.com)}
+# a leading dash would be read by ssh as an option, not a host
+if [[ $STUPID_GIT_DEPLOY_HOST == -* ]]; then
+	echo "Invalid STUPID_GIT_DEPLOY_HOST '$STUPID_GIT_DEPLOY_HOST' (must not start with '-')" >&2
+	exit 2
+fi
+STUPID_GIT_DEPLOY_TAG=${STUPID_GIT_DEPLOY_TAG:-deploy}
+if ! [[ $STUPID_GIT_DEPLOY_TAG =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
+	echo "Invalid STUPID_GIT_DEPLOY_TAG '$STUPID_GIT_DEPLOY_TAG'" >&2
+	exit 2
+fi
+# ~ is expanded on the SERVER (ssh's PATH is minimal, so we give a full path);
+# matches the documented install. Override if `deploy` lives elsewhere.
+STUPID_GIT_DEPLOY_REMOTE=${STUPID_GIT_DEPLOY_REMOTE:-'~/.local/bin/deploy'}
+if ! [[ $STUPID_GIT_DEPLOY_REMOTE =~ ^[A-Za-z0-9~/._][A-Za-z0-9~/._-]*$ ]]; then
+	echo "Invalid STUPID_GIT_DEPLOY_REMOTE '$STUPID_GIT_DEPLOY_REMOTE' (must be a plain path: letters, digits, ~ / . _ -; no leading dash)" >&2
+	exit 2
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+	echo "WARNING: working tree is dirty; the tag will point at committed HEAD, not your uncommitted changes" >&2
+fi
+
+default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)
+default_branch=${default_branch:-main}
+remote_tip=$(git rev-parse --verify --quiet "origin/$default_branch" || true)
+if [ -n "$remote_tip" ] && [ "$(git rev-parse HEAD)" != "$remote_tip" ]; then
+	echo "WARNING: HEAD is not at origin/$default_branch (behind, ahead/unpushed, or diverged); deploying $(git rev-parse --short HEAD) anyway" >&2
+fi
+
+# chained so a failed sign/push never triggers the server. The remote path, site,
+# and SHA expand client-side (intended; the ~ is expanded on the server). The
+# trailing SHA pins the commit we signed so a racing tag update can't swap it.
+# shellcheck disable=SC2029
+git tag -sf "$STUPID_GIT_DEPLOY_TAG" -m "deploy $(git rev-parse --short HEAD)" HEAD \
+	&& git push --force origin "refs/tags/$STUPID_GIT_DEPLOY_TAG" \
+	&& ssh "$STUPID_GIT_DEPLOY_HOST" "$STUPID_GIT_DEPLOY_REMOTE" "$SITE" "$(git rev-parse HEAD)"


### PR DESCRIPTION
Previously `deploy` reset the working tree to whatever the remote branch advertised, with no verification of what it was about to deploy.

Now it only deploys the commit that a git tag named `deploy` (signed with an authorized SSH key) points at, and only as a fast-forward:

- `deploy`: between fetch and checkout, verify the `deploy` tag's SSH signature against a server-side `allowed_signers` file (with an empty `GNUPGHOME` so only that file decides trust), refuse anything that isn't a fast-forward, then reset to the verified commit. Successes and refusals are logged. Requires Git ≥ 2.34, `flock` (util-linux), and OpenSSH (`ssh-keygen`) on the server. A per-site lock stops two deploys of the same site from racing.
- `sign-deploy`: workstation companion that signs the `deploy` tag over local HEAD and triggers the server deploy over SSH. It pins the exact signed commit and the server refuses if the tag moved.

Close #25