### PR TITLE
Route each site to its server via a servers map

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,25 @@ failed, and so on) print a message and exit without a log line.
    `git config --global gpg.format ssh` and
    `git config --global user.signingkey key::ssh-ed25519 AAAA...` (or your 1Password
    config). The *public* key must match a line in the server's `allowed_signers`.
-3. Tell `sign-deploy` where the server is:
-   ```sh
-   export STUPID_GIT_DEPLOY_HOST=your.server.example
+3. Tell `sign-deploy` which server each site deploys to, in
+   `~/.config/deploy/servers` — one `<pattern> <host>` per line, first match wins:
    ```
-   By default it runs `~/.local/bin/deploy` on the server (matching the install
-   above — the `~` is expanded on the server, so it works even if your home
-   directory differs there). Set `STUPID_GIT_DEPLOY_REMOTE` only if you
-   installed `deploy` somewhere else.
+   site-one.example     host1.example.com
+   site-two.example     host1.example.com
+   *.staging.example    host1.example.com
+   *                    host2.example.com
+   ```
+   `<host>` is whatever you'd `ssh` to; mapping many sites onto the same host
+   keeps your `known_hosts` small. The first field is usually a literal site
+   name, but may be a glob — `*.staging.example`, or `*` on the last line as an
+   optional catch-all (keep it last: first match wins). Without a catch-all, an
+   unlisted site is an error. Override the file location with
+   `STUPID_GIT_DEPLOY_SERVERS`, or skip the map for a one-off with
+   `STUPID_GIT_DEPLOY_HOST=your.server.example`.
+
+   By default `sign-deploy` runs `~/.local/bin/deploy` on the server (the `~` is
+   expanded there, so it works even if your home directory differs). Set
+   `STUPID_GIT_DEPLOY_REMOTE` only if you installed `deploy` somewhere else.
 
 ## Deploying
 

--- a/sign-deploy
+++ b/sign-deploy
@@ -11,10 +11,38 @@ if ! [[ $SITE =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
 	echo "Invalid site name '$SITE' (letters, digits, dot, dash, underscore only)" >&2
 	exit 2
 fi
-STUPID_GIT_DEPLOY_HOST=${STUPID_GIT_DEPLOY_HOST:?set STUPID_GIT_DEPLOY_HOST (e.g. export STUPID_GIT_DEPLOY_HOST=deploy.example.com)}
+STUPID_GIT_DEPLOY_HOST=${STUPID_GIT_DEPLOY_HOST:-}
+if [ -z "$STUPID_GIT_DEPLOY_HOST" ]; then
+	STUPID_GIT_DEPLOY_SERVERS=${STUPID_GIT_DEPLOY_SERVERS:-~/.config/deploy/servers}
+	if [ ! -f "$STUPID_GIT_DEPLOY_SERVERS" ] || [ ! -r "$STUPID_GIT_DEPLOY_SERVERS" ]; then
+		echo "no STUPID_GIT_DEPLOY_HOST set and no readable servers map at $STUPID_GIT_DEPLOY_SERVERS (create it, or set STUPID_GIT_DEPLOY_HOST)" >&2
+		exit 2
+	fi
+	lineno=0
+	while IFS=$' \t\r' read -r pattern host _ || [ -n "${pattern:-}" ]; do
+		lineno=$((lineno + 1))
+		pattern=${pattern#$'\xEF\xBB\xBF'}
+		[ -n "$pattern" ] || continue
+		case "$pattern" in \#*) continue ;; esac
+		# shellcheck disable=SC2254 # pattern is an intentional glob from the trusted servers map
+		case "$SITE" in
+			$pattern)
+				if [ -z "$host" ]; then
+					echo "$STUPID_GIT_DEPLOY_SERVERS line $lineno: pattern '$pattern' matches but has no host" >&2
+					exit 2
+				fi
+				STUPID_GIT_DEPLOY_HOST=$host
+				break ;;
+		esac
+	done < "$STUPID_GIT_DEPLOY_SERVERS"
+	if [ -z "$STUPID_GIT_DEPLOY_HOST" ]; then
+		echo "no matching entry for site '$SITE' in $STUPID_GIT_DEPLOY_SERVERS (add a line for it or a '*' catch-all, or set STUPID_GIT_DEPLOY_HOST)" >&2
+		exit 2
+	fi
+fi
 # a leading dash would be read by ssh as an option, not a host
 if [[ $STUPID_GIT_DEPLOY_HOST == -* ]]; then
-	echo "Invalid STUPID_GIT_DEPLOY_HOST '$STUPID_GIT_DEPLOY_HOST' (must not start with '-')" >&2
+	echo "Invalid host '$STUPID_GIT_DEPLOY_HOST' (must not start with '-')" >&2
 	exit 2
 fi
 STUPID_GIT_DEPLOY_TAG=${STUPID_GIT_DEPLOY_TAG:-deploy}


### PR DESCRIPTION
`sign-deploy` required `STUPID_GIT_DEPLOY_HOST` on every invocation, so the site-to-server mapping lived in your head. Add `~/.config/deploy/servers` (overridable via `STUPID_GIT_DEPLOY_SERVERS`): one `<pattern> <host>` per line, first match wins. sign-deploy resolves the site to a host from it; an explicit `STUPID_GIT_DEPLOY_HOST` still overrides, and a leading-dash host is still rejected.

A `*` line is an optional catch-all (route every unlisted site to, say, a demo box); without one, an unlisted site is a clear error. Since ssh keys `known_hosts` by the resolved host, mapping many sites onto a few hosts keeps `known_hosts` small. The wildcard should be specified as the last item, otherwise it will shadow other patterns - the file is processed first-match-wins-style.