### PR TITLE
Deploy tooling polish: SSH-command override, color over non-interactive `ssh`, `ssh`-only wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ failed, and so on) print a message and exit without a log line.
    expanded there, so it works even if your home directory differs). Set
    `STUPID_GIT_DEPLOY_REMOTE` only if you installed `deploy` somewhere else.
 
+   `sign-deploy` connects with `ssh` by default; set `STUPID_GIT_DEPLOY_SSH` to
+   use a different client — e.g. `ssh.exe` on WSL, so authentication uses the
+   Windows-side agent (such as 1Password) instead of WSL's own ssh.
+
 ## Deploying
 
 ```sh

--- a/deploy
+++ b/deploy
@@ -17,6 +17,7 @@ STUPID_GIT_DEPLOY_LOG=${STUPID_GIT_DEPLOY_LOG:-$HOME/.local/state/deploy/deploy.
 STUPID_GIT_DEPLOY_LOCK=${STUPID_GIT_DEPLOY_LOCK:-$HOME/.local/state/deploy/locks/$1.lock}
 VENDOR_PATHDIR=$STUPID_GIT_DEPLOY_ROOT/$1/$VENDOR_DIR
 
+case "${TERM:-}" in ''|dumb) export TERM=xterm-256color ;; esac
 BOLD=$(tput bold)
 RED=$(tput setaf 1)
 GREEN=$(tput setaf 2)

--- a/deploy
+++ b/deploy
@@ -89,16 +89,24 @@ for I in docs conf; do
 	fi
 done
 
-GIT_SSH_KEY=$HOME/.ssh/web-$1.key
-if [ -n "$SELF_DIR" ] && [ -x "$SELF_DIR/$GIT_SSH_WRAPPER" ]; then
-	GIT_SSH=$SELF_DIR/$GIT_SSH_WRAPPER
-else
-	GIT_SSH=$(type -P "$GIT_SSH_WRAPPER")
+# git_ssh_wrapper and the per-site key are only used for an SSH origin
+ORIGIN_URL=$(git remote get-url origin 2>/dev/null)
+case "$ORIGIN_URL" in
+	ssh://*) origin_ssh=1 ;;
+	*://*)   origin_ssh= ;;
+	*:*)     case "${ORIGIN_URL%%:*}" in */*) origin_ssh= ;; *) origin_ssh=1 ;; esac ;;
+	*)       origin_ssh= ;;
+esac
+if [ -n "$origin_ssh" ]; then
+	GIT_SSH_KEY=$HOME/.ssh/web-$1.key
+	if [ -n "$SELF_DIR" ] && [ -x "$SELF_DIR/$GIT_SSH_WRAPPER" ]; then
+		GIT_SSH=$SELF_DIR/$GIT_SSH_WRAPPER
+	else
+		GIT_SSH=$(type -P "$GIT_SSH_WRAPPER")
+	fi
+	[ -n "$GIT_SSH" ] || fail "$GIT_SSH_WRAPPER not found next to the deploy script ($SELF_DIR) or in PATH"
+	export GIT_SSH_KEY GIT_SSH
 fi
-if [ -z "$GIT_SSH" ]; then
-	fail "$GIT_SSH_WRAPPER not found next to the deploy script ($SELF_DIR) or in PATH"
-fi
-export GIT_SSH_KEY GIT_SSH
 
 # Refuse to deploy anything the signed "$STUPID_GIT_DEPLOY_TAG" tag doesn't authorize.
 

--- a/sign-deploy
+++ b/sign-deploy
@@ -57,6 +57,11 @@ if ! [[ $STUPID_GIT_DEPLOY_REMOTE =~ ^[A-Za-z0-9~/._][A-Za-z0-9~/._-]*$ ]]; then
 	echo "Invalid STUPID_GIT_DEPLOY_REMOTE '$STUPID_GIT_DEPLOY_REMOTE' (must be a plain path: letters, digits, ~ / . _ -; no leading dash)" >&2
 	exit 2
 fi
+STUPID_GIT_DEPLOY_SSH=${STUPID_GIT_DEPLOY_SSH:-ssh}
+if ! [[ $STUPID_GIT_DEPLOY_SSH =~ ^[A-Za-z0-9/._][A-Za-z0-9/._-]*$ ]]; then
+	echo "Invalid STUPID_GIT_DEPLOY_SSH '$STUPID_GIT_DEPLOY_SSH' (must be a plain command or path: letters, digits, / . _ -; no leading dash)" >&2
+	exit 2
+fi
 
 if [ -n "$(git status --porcelain)" ]; then
 	echo "WARNING: working tree is dirty; the tag will point at committed HEAD, not your uncommitted changes" >&2
@@ -75,4 +80,4 @@ fi
 # shellcheck disable=SC2029
 git tag -sf "$STUPID_GIT_DEPLOY_TAG" -m "deploy $(git rev-parse --short HEAD)" HEAD \
 	&& git push --force origin "refs/tags/$STUPID_GIT_DEPLOY_TAG" \
-	&& ssh "$STUPID_GIT_DEPLOY_HOST" "$STUPID_GIT_DEPLOY_REMOTE" "$SITE" "$(git rev-parse HEAD)"
+	&& "$STUPID_GIT_DEPLOY_SSH" "$STUPID_GIT_DEPLOY_HOST" "$STUPID_GIT_DEPLOY_REMOTE" "$SITE" "$(git rev-parse HEAD)"


### PR DESCRIPTION
Three small, independent fixes to the deploy tooling. Low-risk, reviewable commit-by-commit. No change to the existing ssh-origin path.

- **`STUPID_GIT_DEPLOY_SSH` override** — `sign-deploy` connects with `ssh` by default; set this to use a different client (e.g. `ssh.exe` on WSL, so auth goes through the Windows-side 1Password agent instead of WSL's own ssh). Validated like the other knobs; documented in the README.
- **Color over non-interactive ssh** — a non-interactive `ssh host cmd` gets `TERM=dumb` (or unset), which killed colored output and printed `tput: No value for $TERM`. `deploy` now maps `''`/`dumb` → `xterm-256color`, restoring color and silencing the warning.
- **Require `git_ssh_wrapper` only for ssh origins** — the wrapper and per-site key exist to inject the deploy key over ssh. `deploy` now demands them only when the origin is actually ssh (`ssh://` or scp-like `host:path`); https/local origins fetch without them.