### PR TITLE
Read site and host from git config, drop the servers map

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ below for exactly what that does and does not buy you.
 ## How it works
 
 1. On your workstation you review what you're about to ship, then run
-   `sign-deploy <site>`. That signs a moving `deploy` tag over your current commit
+   `sign-deploy`. That signs a moving `deploy` tag over your current commit
    (with your SSH key, e.g. from 1Password), force-pushes it, and triggers the
    deploy over ssh.
 2. On the server, `deploy <site>` fetches the tag, checks its signature against a
@@ -75,21 +75,18 @@ failed, and so on) print a message and exit without a log line.
    `git config --global gpg.format ssh` and
    `git config --global user.signingkey key::ssh-ed25519 AAAA...` (or your 1Password
    config). The *public* key must match a line in the server's `allowed_signers`.
-3. Tell `sign-deploy` which server each site deploys to, in
-   `~/.config/deploy/servers` — one `<pattern> <host>` per line, first match wins:
+3. Tell each repository what it deploys and where, with two `git config` values
+   (once per checkout):
+   ```sh
+   git config --local stupid-git-deploy.site michalspacek.cz # what to deploy (the site name)
+   git config --local stupid-git-deploy.host web.example.com # the server to deploy it on
    ```
-   site-one.example     host1.example.com
-   site-two.example     host1.example.com
-   *.staging.example    host1.example.com
-   *                    host2.example.com
-   ```
-   `<host>` is whatever you'd `ssh` to; mapping many sites onto the same host
-   keeps your `known_hosts` small. The first field is usually a literal site
-   name, but may be a glob — `*.staging.example`, or `*` on the last line as an
-   optional catch-all (keep it last: first match wins). Without a catch-all, an
-   unlisted site is an error. Override the file location with
-   `STUPID_GIT_DEPLOY_SERVERS`, or skip the map for a one-off with
-   `STUPID_GIT_DEPLOY_HOST=your.server.example`.
+   Then `sign-deploy` — with no argument — deploys that site. `<host>` is
+   whatever you'd `ssh` to. Pass a site explicitly to override the config
+   (`sign-deploy other.example`), or set
+   `STUPID_GIT_DEPLOY_HOST=your.server.example` for a one-off host. A repository
+   with neither `stupid-git-deploy.site` nor an argument (or with no
+   `stupid-git-deploy.host`) prints how to set them.
 
    By default `sign-deploy` runs `~/.local/bin/deploy` on the server (the `~` is
    expanded there, so it works even if your home directory differs). Set
@@ -104,7 +101,7 @@ failed, and so on) print a message and exit without a log line.
 ```sh
 git pull # get the merged code
 git log --oneline <last>.. # REVIEW what you're about to ship (see below)
-sign-deploy <site> # sign, push the tag, trigger the server
+sign-deploy # sign, push the tag, trigger the server (site from git config)
 ```
 
 Because your signature *is* the authorization, the review step is not optional —

--- a/sign-deploy
+++ b/sign-deploy
@@ -42,6 +42,10 @@ if [[ $STUPID_GIT_DEPLOY_HOST == -* ]]; then
 	echo "Invalid host '$STUPID_GIT_DEPLOY_HOST' (must not start with '-')" >&2
 	exit 2
 fi
+if [[ $STUPID_GIT_DEPLOY_HOST == *[[:space:]]* ]]; then
+	echo "Invalid host '$STUPID_GIT_DEPLOY_HOST' (must not contain whitespace)" >&2
+	exit 2
+fi
 STUPID_GIT_DEPLOY_TAG=${STUPID_GIT_DEPLOY_TAG:-deploy}
 if ! [[ $STUPID_GIT_DEPLOY_TAG =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]]; then
 	echo "Invalid STUPID_GIT_DEPLOY_TAG '$STUPID_GIT_DEPLOY_TAG'" >&2

--- a/sign-deploy
+++ b/sign-deploy
@@ -1,48 +1,41 @@
 #!/usr/bin/env bash
 
-# sign-deploy <site>: sign a "deploy" tag over local HEAD and trigger the
+# sign-deploy [site]: sign a "deploy" tag over local HEAD and trigger the
 # server, which verifies the signature before deploying. Pull and review your
 # changes first: your signature IS the authorization. Warns, never blocks, on a
 # dirty or off-branch HEAD.
 set -euo pipefail
 
-SITE=${1:?usage: sign-deploy <site>}
-if ! [[ $SITE =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
-	echo "Invalid site name '$SITE' (letters, digits, dot, dash, underscore only)" >&2
-	exit 2
-fi
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
 	echo "not a Git repository: $PWD (run sign-deploy from inside the repository you want to deploy)" >&2
 	exit 2
 fi
+
+SITE=${1:-}
+if [ -z "$SITE" ]; then
+	SITE=$(git config --local --get stupid-git-deploy.site 2>/dev/null) || true
+fi
+if [ -z "$SITE" ]; then
+	echo "no site configured for this repository; set it once with" >&2
+	echo "    git config --local stupid-git-deploy.site <site> # what to deploy, e.g. example.com" >&2
+	echo "    git config --local stupid-git-deploy.host <host> # the server to deploy it on" >&2
+	echo "then run sign-deploy again (or pass the site as an argument)" >&2
+	exit 2
+fi
+if ! [[ $SITE =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+	echo "Invalid site name '$SITE' (letters, digits, dot, dash, underscore only)" >&2
+	exit 2
+fi
+
 STUPID_GIT_DEPLOY_HOST=${STUPID_GIT_DEPLOY_HOST:-}
 if [ -z "$STUPID_GIT_DEPLOY_HOST" ]; then
-	STUPID_GIT_DEPLOY_SERVERS=${STUPID_GIT_DEPLOY_SERVERS:-~/.config/deploy/servers}
-	if [ ! -f "$STUPID_GIT_DEPLOY_SERVERS" ] || [ ! -r "$STUPID_GIT_DEPLOY_SERVERS" ]; then
-		echo "no STUPID_GIT_DEPLOY_HOST set and no readable servers map at $STUPID_GIT_DEPLOY_SERVERS (create it, or set STUPID_GIT_DEPLOY_HOST)" >&2
-		exit 2
-	fi
-	lineno=0
-	while IFS=$' \t\r' read -r pattern host _ || [ -n "${pattern:-}" ]; do
-		lineno=$((lineno + 1))
-		pattern=${pattern#$'\xEF\xBB\xBF'}
-		[ -n "$pattern" ] || continue
-		case "$pattern" in \#*) continue ;; esac
-		# shellcheck disable=SC2254 # pattern is an intentional glob from the trusted servers map
-		case "$SITE" in
-			$pattern)
-				if [ -z "$host" ]; then
-					echo "$STUPID_GIT_DEPLOY_SERVERS line $lineno: pattern '$pattern' matches but has no host" >&2
-					exit 2
-				fi
-				STUPID_GIT_DEPLOY_HOST=$host
-				break ;;
-		esac
-	done < "$STUPID_GIT_DEPLOY_SERVERS"
-	if [ -z "$STUPID_GIT_DEPLOY_HOST" ]; then
-		echo "no matching entry for site '$SITE' in $STUPID_GIT_DEPLOY_SERVERS (add a line for it or a '*' catch-all, or set STUPID_GIT_DEPLOY_HOST)" >&2
-		exit 2
-	fi
+	STUPID_GIT_DEPLOY_HOST=$(git config --local --get stupid-git-deploy.host 2>/dev/null) || true
+fi
+if [ -z "$STUPID_GIT_DEPLOY_HOST" ]; then
+	echo "no deploy host configured for '$SITE'; set it once with" >&2
+	echo "    git config --local stupid-git-deploy.host <host>" >&2
+	echo "(or set STUPID_GIT_DEPLOY_HOST=<host> for a one-off)" >&2
+	exit 2
 fi
 # a leading dash would be read by ssh as an option, not a host
 if [[ $STUPID_GIT_DEPLOY_HOST == -* ]]; then


### PR DESCRIPTION
Per-repo `stupid-git-deploy.site`/`.host`, Git parses it, so no more hand-stripping BOMs and newlines. The servers map from #28 is now removed. A site argument and `STUPID_GIT_DEPLOY_HOST` still override.