### PR TITLE
Document the deploy host as an ssh's `[user@]host` destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,15 @@ failed, and so on) print a message and exit without a log line.
    ```sh
    git config --local stupid-git-deploy.site michalspacek.cz # what to deploy (the site name)
    git config --local stupid-git-deploy.host web.example.com # the server to deploy it on
+   git config --local stupid-git-deploy.host ubuntu@web.example.com # ...or [user@]host if the remote login differs
    ```
-   Then `sign-deploy` — with no argument — deploys that site. `<host>` is
-   whatever you'd `ssh` to. Pass a site explicitly to override the config
-   (`sign-deploy other.example`), or set
-   `STUPID_GIT_DEPLOY_HOST=your.server.example` for a one-off host. A repository
-   with neither `stupid-git-deploy.site` nor an argument (or with no
+   Then `sign-deploy` — with no argument — deploys that site. `<[user@]host>` is
+   the ssh *destination* to connect to; include the `user@` when the remote
+   login isn't your local username (without it ssh falls back to your username
+   or `~/.ssh/config`, easy to get wrong). Pass a site explicitly to override
+   the config (`sign-deploy other.example`), or set
+   `STUPID_GIT_DEPLOY_HOST=<[user@]host>` for a one-off. A repository with
+   neither `stupid-git-deploy.site` nor an argument (or with no
    `stupid-git-deploy.host`) prints how to set them.
 
    By default `sign-deploy` runs `~/.local/bin/deploy` on the server (the `~` is

--- a/sign-deploy
+++ b/sign-deploy
@@ -18,7 +18,7 @@ fi
 if [ -z "$SITE" ]; then
 	echo "No site configured for this repository; set it once with" >&2
 	echo "  git config --local stupid-git-deploy.site <site> # what to deploy, e.g. example.com" >&2
-	echo "  git config --local stupid-git-deploy.host <host> # the server to deploy it on" >&2
+	echo "  git config --local stupid-git-deploy.host <[user@]host> # the server to deploy it on" >&2
 	echo "then run sign-deploy again (or pass the site as an argument)" >&2
 	exit 2
 fi
@@ -33,8 +33,8 @@ if [ -z "$STUPID_GIT_DEPLOY_HOST" ]; then
 fi
 if [ -z "$STUPID_GIT_DEPLOY_HOST" ]; then
 	echo "No deploy host configured for '$SITE'; set it once with" >&2
-	echo "  git config --local stupid-git-deploy.host <host>" >&2
-	echo "(or set STUPID_GIT_DEPLOY_HOST=<host> for a one-off)" >&2
+	echo "  git config --local stupid-git-deploy.host <[user@]host>" >&2
+	echo "(or set STUPID_GIT_DEPLOY_HOST=<[user@]host> for a one-off)" >&2
 	exit 2
 fi
 # a leading dash would be read by ssh as an option, not a host


### PR DESCRIPTION
Because *it is* the destination.