### PR TITLE
Add `tests/` suites for `sign-deploy` and `deploy`, run in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,14 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run tests
+        run: bash tests/run.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+external-sources=true
+source-path=SCRIPTDIR

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,68 @@
+# shellcheck shell=bash
+# Shared helpers for the test suites. Nothing here signs, pushes, or ssh's.
+# Output is Markdown: ## per test case, - per assertion.
+
+work=$(mktemp --directory)
+trap 'rm --recursive --force "$work"' EXIT
+
+# Sandbox git so the suites can't touch the real HOME, signing key, or system
+# config, or discover a repo above the work dir.
+export HOME=$work/home
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_CEILING_DIRECTORIES=$work
+mkdir --parents "$HOME"
+
+pass=0
+fail=0
+
+testcase() {
+	echo
+	echo "## $*"
+}
+
+contains() {
+	local needle=$1 haystack=$2 description=$3
+	if printf '%s' "$haystack" | grep --quiet --fixed-strings -- "$needle"; then
+		echo "- ok: $description"
+		pass=$((pass + 1))
+	else
+		echo "- FAIL: $description (got: $(printf '%s' "$haystack" | head --lines=2 | tr '\n' '|'))"
+		fail=$((fail + 1))
+	fi
+}
+
+notcontains() {
+	local needle=$1 haystack=$2 description=$3
+	if printf '%s' "$haystack" | grep --quiet --fixed-strings -- "$needle"; then
+		echo "- FAIL: $description (unexpected: $needle)"
+		fail=$((fail + 1))
+	else
+		echo "- ok: $description"
+		pass=$((pass + 1))
+	fi
+}
+
+exits() {
+	local want=$1 got=$2 description=$3
+	if [ "$got" = "$want" ]; then
+		echo "- ok: $description"
+		pass=$((pass + 1))
+	else
+		echo "- FAIL: $description (exit $got, want $want)"
+		fail=$((fail + 1))
+	fi
+}
+
+newrepo() {
+	local repo
+	repo=$(mktemp --directory "$work/repo.XXXXXX")
+	git init --quiet "$repo"
+	git -C "$repo" -c user.name=test -c user.email=test@example commit --quiet --allow-empty --message init
+	echo "$repo"
+}
+
+summary() {
+	echo
+	echo "\`${0##*/}\`: pass=$pass fail=$fail"
+	[ "$fail" -eq 0 ]
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Run every test-*.sh suite in this directory; exit non-zero if any suite fails.
+set -u
+dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+count=$(find "$dir" -maxdepth 1 -name 'test-*.sh' | wc --lines)
+if [ "$count" -eq 0 ]; then
+	echo "No test suites (test-*.sh) found in $dir" >&2
+	exit 1
+fi
+
+exit_code=0
+for suite in "$dir"/test-*.sh; do
+	if [ -n "${printed:-}" ]; then
+		echo
+	fi
+	printed=1
+	echo "# ${suite##*/}"
+	bash "$suite" || exit_code=1
+done
+exit "$exit_code"

--- a/tests/test-deploy.sh
+++ b/tests/test-deploy.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -u
+# shellcheck source=lib.sh
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+deploy=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/deploy
+
+# Input validation: the guards that run before flock.
+root=$(mktemp --directory "$work/root.XXXXXX"); mkdir "$root/site-a" "$root/site-b"
+
+testcase "No argument: usage lists the available sites"
+out=$( STUPID_GIT_DEPLOY_ROOT="$root" bash "$deploy" 2>&1 )
+contains "<site> is one of:" "$out" "shows the site-list header"
+contains "site-a" "$out" "lists a site directory"
+
+testcase "Invalid site name is rejected"
+out=$( STUPID_GIT_DEPLOY_ROOT="$root" bash "$deploy" 'bad!name' 2>&1 )
+exit_code=$?
+contains "Invalid site name 'bad!name'" "$out" "invalid site rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Unsafe STUPID_GIT_DEPLOY_ROOT is rejected"
+out=$( STUPID_GIT_DEPLOY_ROOT="-evil" bash "$deploy" site-a 2>&1 )
+exit_code=$?
+contains "Unsafe STUPID_GIT_DEPLOY_ROOT" "$out" "unsafe root rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Unsafe STUPID_GIT_DEPLOY_TAG is rejected"
+out=$( STUPID_GIT_DEPLOY_ROOT="$root" STUPID_GIT_DEPLOY_TAG="-evil" bash "$deploy" site-a 2>&1 )
+exit_code=$?
+contains "Unsafe STUPID_GIT_DEPLOY_TAG" "$out" "unsafe tag rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "A site that does not exist is rejected"
+out=$( STUPID_GIT_DEPLOY_ROOT="$root" bash "$deploy" nosuchsite 2>&1 )
+exit_code=$?
+contains "Site nosuchsite doesn't exist" "$out" "missing site rejected"
+exits 2 "$exit_code" "exits 2"
+
+# Security core: signature verification, fast-forward, SHA pin. Offline fixture:
+# a bare origin (c1 -> c2 on main), a throwaway ssh signing key with an
+# allowed_signers, and a per-test site checkout cloned from that origin.
+ssh-keygen -t ed25519 -N '' -q -f "$work/id"
+ssh-keygen -t ed25519 -N '' -q -f "$work/foreign"
+signers=$work/allowed_signers
+printf 'test@example %s\n' "$(awk '{print $1, $2}' "$work/id.pub")" > "$signers"
+
+# Stub curl so the deploy healthcheck never touches the network.
+mkdir --parents "$work/bin"
+printf '#!/bin/sh\nexit 0\n' > "$work/bin/curl"
+chmod +x "$work/bin/curl"
+
+siteroot=$(mktemp --directory "$work/siteroot.XXXXXX")
+origin=$work/origin.git
+git init --quiet --bare --initial-branch=main "$origin"
+build=$work/build
+git init --quiet "$build"
+git -C "$build" remote add origin "$origin"
+
+git_build() {
+	git -C "$build" -c user.name=test -c user.email=test@example "$@"
+}
+
+git_build commit --quiet --allow-empty --message c1
+git_build push --quiet origin HEAD:refs/heads/main
+c1=$(git_build rev-parse HEAD)
+git_build commit --quiet --allow-empty --message c2
+git_build push --quiet origin HEAD:refs/heads/main
+c2=$(git_build rev-parse HEAD)
+
+# An empty signing key makes an unsigned lightweight tag.
+tag_deploy() {
+	if [ -n "$2" ]; then
+		git_build -c gpg.format=ssh -c user.signingkey="$2" \
+			tag --sign --force --message "deploy $(git_build rev-parse --short "$1")" deploy "$1"
+	else
+		git_build tag --force deploy "$1"
+	fi
+	git_build push --force origin refs/tags/deploy
+} >/dev/null 2>&1
+
+site_at() {
+	git clone --quiet "$origin" "$siteroot/$1" 2>/dev/null
+	git -C "$siteroot/$1" checkout --quiet "$2"
+}
+
+run_deploy() {
+	PATH="$work/bin:$PATH" STUPID_GIT_DEPLOY_ROOT="$siteroot" STUPID_GIT_DEPLOY_ALLOWED_SIGNERS="$signers" \
+		STUPID_GIT_DEPLOY_LOG="$work/deploy.log" STUPID_GIT_DEPLOY_LOCK="$work/deploy.lock" \
+		bash "$deploy" "$1" "${2:-}" 2>&1
+}
+
+testcase "A valid signed fast-forward deploys"
+site_at ok.invalid "$c1"
+tag_deploy "$c2" "$work/id"
+out=$( run_deploy ok.invalid "$c2" )
+exit_code=$?
+contains "Good" "$out" "signature verified"
+contains "successfully deployed" "$out" "deploy completed"
+exits 0 "$exit_code" "exits 0"
+
+testcase "An unsigned deploy tag is refused"
+site_at unsigned.invalid "$c1"
+tag_deploy "$c2" ""
+out=$( run_deploy unsigned.invalid "$c2" )
+exit_code=$?
+contains "NOT signed by an authorized key" "$out" "unsigned tag refused"
+exits 1 "$exit_code" "exits non-zero"
+
+testcase "A tag signed by an unauthorized key is refused"
+site_at foreign.invalid "$c1"
+tag_deploy "$c2" "$work/foreign"
+out=$( run_deploy foreign.invalid "$c2" )
+exit_code=$?
+contains "NOT signed by an authorized key" "$out" "foreign-key tag refused"
+exits 1 "$exit_code" "exits non-zero"
+
+testcase "A non-fast-forward (rollback) is refused"
+site_at rollback.invalid "$c2"
+tag_deploy "$c1" "$work/id"
+out=$( run_deploy rollback.invalid "$c1" )
+exit_code=$?
+contains "not a fast-forward" "$out" "rollback refused"
+exits 1 "$exit_code" "exits non-zero"
+
+testcase "A tag not pointing at the signed commit is refused (SHA pin)"
+site_at shapin.invalid "$c1"
+tag_deploy "$c2" "$work/id"
+# the tag is at c2; passing c1 as the signed commit must be refused
+out=$( run_deploy shapin.invalid "$c1" )
+exit_code=$?
+contains "not the commit you signed" "$out" "SHA-pin mismatch refused"
+exits 1 "$exit_code" "exits non-zero"
+
+summary

--- a/tests/test-sign-deploy.sh
+++ b/tests/test-sign-deploy.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -u
+# shellcheck source=lib.sh
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+sign_deploy=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/sign-deploy
+
+# A repo with both values configured, the base for the validation cases below.
+configured() {
+	local repo
+	repo=$(newrepo)
+	git -C "$repo" config stupid-git-deploy.site ok.example
+	git -C "$repo" config stupid-git-deploy.host web.example.com
+	echo "$repo"
+}
+
+# For the cases that run past validation: an SSH signing key in local config, an
+# origin to push the deploy tag to, and a stub that records the trigger instead
+# of ssh'ing anywhere. deployable() returns such a repo, with HEAD at origin's
+# tip so it neither warns nor blocks by default.
+signer=$work/signer
+ssh-keygen -t ed25519 -N '' -q -f "$signer"
+signers=$work/allowed_signers
+printf 'test@example %s\n' "$(awk '{print $1, $2}' "$signer.pub")" > "$signers"
+mkdir --parents "$work/bin"
+printf '#!/bin/sh\nprintf "%%s\\n" "$@" > "%s/trigger.args"\n' "$work" > "$work/bin/trigger"
+chmod +x "$work/bin/trigger"
+
+deployable() {
+	local repo bare
+	repo=$(newrepo)
+	git -C "$repo" config user.name test
+	git -C "$repo" config user.email test@example
+	git -C "$repo" config gpg.format ssh
+	git -C "$repo" config user.signingkey "$signer"
+	git -C "$repo" config stupid-git-deploy.site ok.example
+	git -C "$repo" config stupid-git-deploy.host web.example.com
+	bare=$(mktemp --directory "$work/deployable.XXXXXX")
+	git init --quiet --bare --initial-branch=main "$bare"
+	git -C "$repo" remote add origin "$bare"
+	git -C "$repo" push --quiet origin HEAD:refs/heads/main
+	echo "$repo"
+}
+
+testcase "No config and no argument: prints setup help"
+repo=$(newrepo); out=$( cd "$repo" && bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "No site configured for this repository" "$out" "says 'No site configured'"
+contains "git config --local stupid-git-deploy.site <site>" "$out" "shows the git config command"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Site from config, host missing: resolves site, asks for host"
+repo=$(newrepo); git -C "$repo" config stupid-git-deploy.site cfgsite.example
+out=$( cd "$repo" && bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "No deploy host configured for 'cfgsite.example'" "$out" "site came from config"
+contains "git config --local stupid-git-deploy.host <[user@]host>" "$out" "host help shows [user@]host"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Argument overrides the configured site"
+repo=$(newrepo); git -C "$repo" config stupid-git-deploy.site cfgsite.example
+out=$( cd "$repo" && bash "$sign_deploy" argsite.example 2>&1 )
+exit_code=$?
+contains "No deploy host configured for 'argsite.example'" "$out" "argument wins over config"
+exits 2 "$exit_code" "exits 2"
+
+testcase "A fully configured repo signs the tag, pushes it, and triggers the host"
+repo=$(deployable)
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_SSH="$work/bin/trigger" bash "$sign_deploy" 2>&1 )
+exit_code=$?
+exits 0 "$exit_code" "sign-deploy completes"
+contains "Good" "$(git -C "$repo" -c gpg.ssh.allowedSignersFile="$signers" tag --verify deploy 2>&1)" "deploy tag is signed by the authorized key"
+contains "refs/tags/deploy" "$(git -C "$repo" ls-remote origin)" "deploy tag pushed to origin"
+trigger=$(cat "$work/trigger.args")
+contains "ok.example" "$trigger" "triggered the host with the site"
+contains "$(git -C "$repo" rev-parse HEAD)" "$trigger" "triggered with the signed commit SHA"
+
+testcase "Invalid site from config is rejected"
+repo=$(newrepo); git -C "$repo" config stupid-git-deploy.site 'bad!name'
+out=$( cd "$repo" && bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "Invalid site name 'bad!name'" "$out" "invalid site rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Leading-dash host is rejected (option injection)"
+repo=$(newrepo); git -C "$repo" config stupid-git-deploy.site ok.example; git -C "$repo" config stupid-git-deploy.host '-oProxyCommand=x'
+out=$( cd "$repo" && bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "must not start with '-'" "$out" "leading-dash host rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "STUPID_GIT_DEPLOY_HOST overrides the configured host"
+repo=$(newrepo); git -C "$repo" config stupid-git-deploy.site ok.example; git -C "$repo" config stupid-git-deploy.host goodhost.example
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_HOST=-envbad bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "Invalid host '-envbad'" "$out" "env host used, not config"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Whitespace host is rejected before the trigger"
+repo=$(newrepo); git -C "$repo" config stupid-git-deploy.site ok.example; git -C "$repo" config stupid-git-deploy.host "   "
+out=$( cd "$repo" && bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "must not contain whitespace" "$out" "whitespace host (config) rejected"
+exits 2 "$exit_code" "exits 2"
+repo=$(newrepo); git -C "$repo" config stupid-git-deploy.site ok.example
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_HOST="   " bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "must not contain whitespace" "$out" "whitespace host (env) rejected"
+exits 2 "$exit_code" "exits 2"
+repo=$(newrepo); git -C "$repo" config stupid-git-deploy.site ok.example; git -C "$repo" config stupid-git-deploy.host "web.example.com x"
+out=$( cd "$repo" && bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "must not contain whitespace" "$out" "internal-whitespace host rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Invalid STUPID_GIT_DEPLOY_TAG is rejected"
+repo=$(configured)
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_TAG=-bad bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "Invalid STUPID_GIT_DEPLOY_TAG" "$out" "bad tag rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Invalid STUPID_GIT_DEPLOY_REMOTE is rejected"
+repo=$(configured)
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_REMOTE='a b' bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "Invalid STUPID_GIT_DEPLOY_REMOTE" "$out" "bad remote rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Invalid STUPID_GIT_DEPLOY_SSH is rejected"
+repo=$(configured)
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_SSH=-bad bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "Invalid STUPID_GIT_DEPLOY_SSH" "$out" "bad ssh command rejected"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Outside a Git repository: errors first"
+nonrepo=$(mktemp --directory "$work/nonrepo.XXXXXX")
+out=$( cd "$nonrepo" && bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "Not a Git repository" "$out" "not-a-repo message"
+exits 2 "$exit_code" "exits 2"
+
+testcase "A global git config value does not leak past --local"
+repo=$(newrepo); home=$(mktemp --directory "$work/home.XXXXXX")
+HOME="$home" git config --global stupid-git-deploy.site globalsite.example
+HOME="$home" git config --global stupid-git-deploy.host globalhost.example
+out=$( cd "$repo" && HOME="$home" bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "No site configured" "$out" "global site ignored (no local)"
+exits 2 "$exit_code" "exits 2"
+git -C "$repo" config stupid-git-deploy.site local.example
+out=$( cd "$repo" && HOME="$home" bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "No deploy host configured for 'local.example'" "$out" "global host ignored (local site set)"
+exits 2 "$exit_code" "exits 2"
+
+testcase "Warns but still deploys when the working tree is dirty"
+repo=$(deployable); touch "$repo/uncommitted"
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_SSH="$work/bin/trigger" bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "Working tree is dirty" "$out" "dirty-tree warning fires"
+exits 0 "$exit_code" "warns but does not block"
+
+testcase "Warns but still deploys when HEAD is not at origin's default branch"
+repo=$(deployable)
+git -C "$repo" -c user.name=test -c user.email=test@example commit --quiet --allow-empty --message ahead
+git -C "$repo" fetch --quiet origin
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_SSH="$work/bin/trigger" bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "HEAD is not at origin/" "$out" "off-branch warning fires"
+exits 0 "$exit_code" "warns but does not block"
+
+summary


### PR DESCRIPTION
- Shared helpers in `tests/lib.sh` with Git sandboxed to a throwaway `HOME`, so no real config/signing key is ever touched
- Per-script suites drive the real scripts against throwaway repos
- `tests/run.sh` runs all suites and the Tests workflow calls it
- `.shellcheckrc` lets shellcheck follow the sourced lib