### PR TITLE
Include the date in the deploy tag message

### DIFF
--- a/sign-deploy
+++ b/sign-deploy
@@ -79,6 +79,6 @@ fi
 # and SHA expand client-side (intended; the ~ is expanded on the server). The
 # trailing SHA pins the commit we signed so a racing tag update can't swap it.
 # shellcheck disable=SC2029
-git tag --sign --force --message "Deploy $(git rev-parse --short HEAD)" "$STUPID_GIT_DEPLOY_TAG" HEAD \
+git tag --sign --force --message "Deploy $(git rev-parse --short HEAD) $(date -u +%Y-%m-%dT%H:%M:%SZ)" "$STUPID_GIT_DEPLOY_TAG" HEAD \
 	&& git push --force origin "refs/tags/$STUPID_GIT_DEPLOY_TAG" \
 	&& "$STUPID_GIT_DEPLOY_SSH" "$STUPID_GIT_DEPLOY_HOST" "$STUPID_GIT_DEPLOY_REMOTE" "$SITE" "$(git rev-parse HEAD)"

--- a/tests/test-deploy.sh
+++ b/tests/test-deploy.sh
@@ -71,7 +71,7 @@ c2=$(git_build rev-parse HEAD)
 tag_deploy() {
 	if [ -n "$2" ]; then
 		git_build -c gpg.format=ssh -c user.signingkey="$2" \
-			tag --sign --force --message "Deploy $(git_build rev-parse --short "$1")" deploy "$1"
+			tag --sign --force --message "Deploy $(git_build rev-parse --short "$1") $(date -u +%Y-%m-%dT%H:%M:%SZ)" deploy "$1"
 	else
 		git_build tag --force deploy "$1"
 	fi


### PR DESCRIPTION
Now "Deploy <commit sha> <date>" (via a portable UTC RFC-3339); the test fixture mirrors it.