### PR TITLE
Pre-flight the deploy host before moving the deploy tag

### DIFF
--- a/sign-deploy
+++ b/sign-deploy
@@ -75,10 +75,19 @@ if [ -n "$remote_tip" ] && [ "$(git rev-parse HEAD)" != "$remote_tip" ]; then
 	echo "WARNING: HEAD is not at origin/$default_branch (behind, ahead/unpushed, or diverged); deploying $(git rev-parse --short HEAD) anyway" >&2
 fi
 
-# chained so a failed sign/push never triggers the server. The remote path, site,
-# and SHA expand client-side (intended; the ~ is expanded on the server). The
-# trailing SHA pins the commit we signed so a racing tag update can't swap it.
+# Fail before moving the tag if the deploy host is unreachable.
+if ! "$STUPID_GIT_DEPLOY_SSH" "$STUPID_GIT_DEPLOY_HOST" true >/dev/null; then
+	echo "Cannot reach the deploy host over SSH ('$STUPID_GIT_DEPLOY_SSH' '$STUPID_GIT_DEPLOY_HOST'); nothing signed or pushed" >&2
+	exit 1
+fi
+
+git tag --sign --force --message "Deploy $(git rev-parse --short HEAD) $(date -u +%Y-%m-%dT%H:%M:%SZ)" "$STUPID_GIT_DEPLOY_TAG" HEAD
+git push --force origin "refs/tags/$STUPID_GIT_DEPLOY_TAG"
+
+# The remote path, site, and SHA expand client-side (intended; the ~ is expanded on the server).
+# The trailing SHA pins the commit we signed so a racing tag update can't swap it.
 # shellcheck disable=SC2029
-git tag --sign --force --message "Deploy $(git rev-parse --short HEAD) $(date -u +%Y-%m-%dT%H:%M:%SZ)" "$STUPID_GIT_DEPLOY_TAG" HEAD \
-	&& git push --force origin "refs/tags/$STUPID_GIT_DEPLOY_TAG" \
-	&& "$STUPID_GIT_DEPLOY_SSH" "$STUPID_GIT_DEPLOY_HOST" "$STUPID_GIT_DEPLOY_REMOTE" "$SITE" "$(git rev-parse HEAD)"
+if ! "$STUPID_GIT_DEPLOY_SSH" "$STUPID_GIT_DEPLOY_HOST" "$STUPID_GIT_DEPLOY_REMOTE" "$SITE" "$(git rev-parse HEAD)"; then
+	echo "The '$STUPID_GIT_DEPLOY_TAG' tag was signed and pushed, but the deploy did not succeed on '$STUPID_GIT_DEPLOY_HOST' (see the output above). Re-run sign-deploy after fixing the cause, or run '$STUPID_GIT_DEPLOY_REMOTE $SITE' on the server." >&2
+	exit 1
+fi

--- a/tests/test-sign-deploy.sh
+++ b/tests/test-sign-deploy.sh
@@ -170,4 +170,24 @@ exit_code=$?
 contains "HEAD is not at origin/" "$out" "off-branch warning fires"
 exits 0 "$exit_code" "warns but does not block"
 
+testcase "An unreachable deploy host is caught before the tag moves"
+repo=$(deployable)
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_SSH=false bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "Cannot reach the deploy host" "$out" "pre-flight failure reported"
+exits 1 "$exit_code" "exits non-zero"
+tagref=$(git -C "$repo" rev-parse --verify --quiet refs/tags/deploy || echo none)
+contains "none" "$tagref" "deploy tag was not created (nothing moved)"
+
+testcase "A failed deploy after a reachable host is reported, with the tag already pushed"
+repo=$(deployable)
+# shellcheck disable=SC2016 # $2 is the stub's own arg, expanded when the stub runs
+printf '#!/bin/sh\ncase "$2" in true) exit 0 ;; *) echo boom >&2; exit 1 ;; esac\n' > "$work/bin/flaky"
+chmod +x "$work/bin/flaky"
+out=$( cd "$repo" && STUPID_GIT_DEPLOY_SSH="$work/bin/flaky" bash "$sign_deploy" 2>&1 )
+exit_code=$?
+contains "did not succeed" "$out" "deploy failure reported clearly"
+exits 1 "$exit_code" "exits non-zero"
+contains "refs/tags/deploy" "$(git -C "$repo" ls-remote origin)" "tag was still pushed (authorization recorded)"
+
 summary


### PR DESCRIPTION
A broken SSH now fails before signing/pushing (not after, which left the tag ahead of the server); a trigger failure past a reachable host is reported clearly, with the tag already pushed.